### PR TITLE
Think that I found a bug on Parallel iterator

### DIFF
--- a/parallel_test.go
+++ b/parallel_test.go
@@ -16,7 +16,7 @@ func TestParallelShouldNotPanic(t *testing.T) {
 	xs := []int{}
 
 	for range 10000 {
-		xs = append(xs)
+		xs = append(xs, 0)
 	}
 
 	for i, _ := range loop.Parallel(xs) {

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -1,6 +1,7 @@
 package loop_test
 
 import (
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ func TestParallelShouldNotPanic(t *testing.T) {
 	}
 
 	for i, _ := range loop.Parallel(xs) {
+		fmt.Println("hello")
 		if i > 300 {
 			break
 		}


### PR DESCRIPTION
First, sorry if I forgot something, but it's 1:18 AM and I start feeling tired and I need to sleep.

For the moment, I don't know if this is something that happens only on my machine. But even on another project with similar codebase, it breaks running on the golang official docker image.

To replicate the bug, run the test `TestParallelShouldNotPanic` with the following command

    GOEXPERIMENT=rangefunc go test -v ./... -count=1 -run TestParallelShouldNotPanic

This command disables test caching and runs only the specified test function. Also, the test initially doesn't even run because when you are appending on the slice it doesn't really append anything and the condition doesn't event executes.

As I put on my commit:
> fix:iterators seems to not be concurrent
>
> initially if the iteration has just a conditional it doesn't panic. After putting some code 
like fmt.Println (which I think that adds some latency) the yield function call panics. I 
think that iterators are not designed to run multiple yield functions at the same time.